### PR TITLE
Enabling setting target_arch when building

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ TODO
 
 ### Building
 
-    $ script/build
+    $ script/update -t x64
+    $ script/build -t x64
 
 ### Updating project files
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -25,10 +25,6 @@ def main():
     if os.path.isdir(os.path.join(SRC_DIR, '.git')):
         rm_rf(SRC_DIR)
 
-    os.chdir(SOURCE_ROOT)
-    update = os.path.join(SOURCE_ROOT, 'script', 'update')
-    return subprocess.call([sys.executable, update])
-
 
 def rm_rf(path):
     try:

--- a/script/build
+++ b/script/build
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import argparse
 import os
 import subprocess
 import sys
@@ -17,10 +18,23 @@ if sys.platform == 'win32':
 
 
 def main():
-    os.chdir(SOURCE_ROOT)
-    for config in CONFIGURATIONS:
-        config_dir = os.path.relpath(os.path.join(OUT_DIR, config))
-        subprocess.check_call([NINJA, '-C', config_dir] + TARGETS)
+  args = parse_args()
+
+  # Build dir is "out32" for 32bit builds.
+  global OUT_DIR
+  if args.target_arch == 'ia32':
+    OUT_DIR += '32'
+
+  os.chdir(SOURCE_ROOT)
+  for config in CONFIGURATIONS:
+      config_dir = os.path.relpath(os.path.join(OUT_DIR, config))
+      subprocess.check_call([NINJA, '-C', config_dir] + TARGETS)
+
+
+def parse_args():
+  parser = argparse.ArgumentParser(description='Build libchromiumcontent')
+  parser.add_argument('-t', '--target_arch', default='x64', help='x64 or ia32')
+  return parser.parse_args()
 
 
 if __name__ == '__main__':

--- a/script/build
+++ b/script/build
@@ -27,8 +27,10 @@ def main():
 
   os.chdir(SOURCE_ROOT)
   for config in CONFIGURATIONS:
-      config_dir = os.path.relpath(os.path.join(OUT_DIR, config))
-      subprocess.check_call([NINJA, '-C', config_dir] + TARGETS)
+    if args.target_arch == 'x64' and sys.platform in ['win32', 'cygwin']:
+      config += '_x64'
+    config_dir = os.path.relpath(os.path.join(OUT_DIR, config))
+    subprocess.check_call([NINJA, '-C', config_dir] + TARGETS)
 
 
 def parse_args():

--- a/script/build
+++ b/script/build
@@ -8,7 +8,6 @@ import sys
 
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 VENDOR_DIR = os.path.join(SOURCE_ROOT, 'vendor')
-OUT_DIR = os.path.join(VENDOR_DIR, 'chromium', 'src', 'out')
 TARGETS = ['chromiumcontent_all']
 CONFIGURATIONS = ['Debug', 'Release']
 
@@ -21,15 +20,15 @@ def main():
   args = parse_args()
 
   # Build dir is "out32" for 32bit builds.
-  global OUT_DIR
+  out_dir = os.path.join(VENDOR_DIR, 'chromium', 'src', 'out')
   if args.target_arch == 'ia32':
-    OUT_DIR += '32'
+    out_dir += '32'
 
   os.chdir(SOURCE_ROOT)
   for config in CONFIGURATIONS:
     if args.target_arch == 'x64' and sys.platform in ['win32', 'cygwin']:
       config += '_x64'
-    config_dir = os.path.relpath(os.path.join(OUT_DIR, config))
+    config_dir = os.path.relpath(os.path.join(out_dir, config))
     subprocess.check_call([NINJA, '-C', config_dir] + TARGETS)
 
 

--- a/script/cibuild
+++ b/script/cibuild
@@ -13,18 +13,22 @@ S3_CREDENTIALS_FILE = os.path.join(JENKINS_ROOT, 'config', 's3credentials')
 
 
 def main():
-    if not os.path.isfile(S3_CREDENTIALS_FILE):
-        return 'Error: Can\'t find {0}'.format(S3_CREDENTIALS_FILE)
-    copy_to_environment(S3_CREDENTIALS_FILE)
+  if not os.path.isfile(S3_CREDENTIALS_FILE):
+    return 'Error: Can\'t find {0}'.format(S3_CREDENTIALS_FILE)
+  copy_to_environment(S3_CREDENTIALS_FILE)
 
-    print 'Python version:', platform.python_version()
-    print 'OS version:', os_version()
+  print 'Python version:', platform.python_version()
+  print 'OS version:', os_version()
 
-    return (run_script('bootstrap') or
-            run_script('update') or
-            run_script('build') or
-            run_script('create-dist') or
-            run_script('upload'))
+  args = []
+  if sys.platform in ['win32', 'cygwin']:
+    args = ['-t', 'ia32']
+
+  return (run_script('bootstrap') or
+          run_script('update', args) or
+          run_script('build', args) or
+          run_script('create-dist', args) or
+          run_script('upload', args))
 
 
 def copy_to_environment(credentials_file):
@@ -46,11 +50,11 @@ def os_version():
     return platform.platform()
 
 
-def run_script(script):
-    script = os.path.join('script', script)
-    sys.stderr.write('+ {0}\n'.format(script))
-    sys.stderr.flush()
-    return subprocess.call([sys.executable, script])
+def run_script(script, args=[]):
+  script = os.path.join('script', script)
+  sys.stderr.write('+ {0}\n'.format(script))
+  sys.stderr.flush()
+  return subprocess.call([sys.executable, script] + args)
 
 
 if __name__ == '__main__':

--- a/script/cibuild
+++ b/script/cibuild
@@ -21,6 +21,7 @@ def main():
     print 'OS version:', os_version()
 
     return (run_script('bootstrap') or
+            run_script('update') or
             run_script('build') or
             run_script('create-dist') or
             run_script('upload'))

--- a/script/create-dist
+++ b/script/create-dist
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import argparse
 import contextlib
 import errno
 import os
@@ -162,15 +163,28 @@ OTHER_SOURCES = [
 
 
 def main():
-    rm_rf(DIST_DIR)
-    os.makedirs(DIST_DIR)
+  args = parse_args()
 
-    copy_binaries()
-    objcopy_with_debug_info()
-    create_dsym()
-    copy_symbols()
-    copy_sources()
-    create_zip()
+  # Build dir is "out32" for 32bit builds.
+  global OUT_DIR
+  if args.target_arch == 'ia32':
+    OUT_DIR += '32'
+
+  rm_rf(DIST_DIR)
+  os.makedirs(DIST_DIR)
+
+  copy_binaries()
+  objcopy_with_debug_info()
+  create_dsym()
+  copy_symbols()
+  copy_sources()
+  create_zip()
+
+
+def parse_args():
+  parser = argparse.ArgumentParser(description='Create distribution')
+  parser.add_argument('-t', '--target_arch', default='x64', help='x64 or ia32')
+  return parser.parse_args()
 
 
 def copy_binaries():

--- a/script/create-dist
+++ b/script/create-dist
@@ -13,8 +13,6 @@ import zipfile
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 DIST_DIR = os.path.join(SOURCE_ROOT, 'dist')
 SRC_DIR = os.path.join(SOURCE_ROOT, 'vendor', 'chromium', 'src')
-OUT_DIR = os.path.join(SRC_DIR, 'out')
-SYMBOLS_INTERMEDIATE_DIR = os.path.join(OUT_DIR, 'symbols')
 DSYM_DYLIB_PATH = os.path.join('libchromiumcontent.dylib.dSYM', 'Contents',
                                'Resources', 'DWARF',
                                'libchromiumcontent.dylib')
@@ -166,18 +164,18 @@ def main():
   args = parse_args()
 
   # Build dir is "out32" for 32bit builds.
-  global OUT_DIR
+  out_dir = os.path.join(SRC_DIR, 'out')
   if args.target_arch == 'ia32':
-    OUT_DIR += '32'
+    out_dir += '32'
 
   rm_rf(DIST_DIR)
   os.makedirs(DIST_DIR)
 
-  copy_binaries()
-  objcopy_with_debug_info()
-  create_dsym()
-  copy_symbols()
-  copy_sources()
+  copy_binaries(out_dir)
+  objcopy_with_debug_info(out_dir)
+  create_dsym(out_dir)
+  copy_symbols(out_dir)
+  copy_sources(out_dir)
   create_zip()
 
 
@@ -187,13 +185,13 @@ def parse_args():
   return parser.parse_args()
 
 
-def copy_binaries():
+def copy_binaries(out_dir):
     for config in CONFIGURATIONS:
         config_dir = os.path.join(MAIN_DIR, config)
         mkdir_p(config_dir)
 
         for binary in BINARIES['all'] + BINARIES[TARGET_PLATFORM]:
-            shutil.copy2(os.path.join(OUT_DIR, config, binary), config_dir)
+            shutil.copy2(os.path.join(out_dir, config, binary), config_dir)
 
         # Strip the copied binaries on Linux since they contain quite large
         # debug info.
@@ -206,54 +204,56 @@ def copy_binaries():
                     subprocess.check_call(['strip', binary_path])
 
 
-def create_dsym():
+def create_dsym(out_dir):
     if sys.platform != 'darwin':
         return
 
     # FIXME: We should probably do this as part of the build, not as part of
     # create-dist.
 
-    source = os.path.join(OUT_DIR, 'Release', DSYM_DYLIB_PATH)
-    destination = os.path.join(SYMBOLS_INTERMEDIATE_DIR, DSYM_DYLIB_PATH)
+    symbols_intermediate_dir = os.path.join(out_dir, 'symbols')
+    source = os.path.join(out_dir, 'Release', DSYM_DYLIB_PATH)
+    destination = os.path.join(symbols_intermediate_dir, DSYM_DYLIB_PATH)
 
     if is_newer(destination, source):
         return
 
     print "Creating dSYM..."
-    mkdir_p(SYMBOLS_INTERMEDIATE_DIR)
-    destination_dsym = os.path.join(SYMBOLS_INTERMEDIATE_DIR,
+    mkdir_p(symbols_intermediate_dir)
+    destination_dsym = os.path.join(symbols_intermediate_dir,
                                     'libchromiumcontent.dylib.dSYM')
     rm_rf(destination_dsym)
     subprocess.check_call(['dsymutil', source, '-o', destination_dsym])
 
 
-def objcopy_with_debug_info():
+def objcopy_with_debug_info(out_dir):
     if TARGET_PLATFORM != 'linux':
         return
 
     for config in CONFIGURATIONS:
         for binary in BINARIES[TARGET_PLATFORM]:
-            source = os.path.join(OUT_DIR, config, binary)
+            source = os.path.join(out_dir, config, binary)
             symbol_name = os.path.basename(binary) + ".dbg"
             if symbol_name in SYMBOLS[TARGET_PLATFORM]:
-                destination = os.path.join(OUT_DIR, config, symbol_name)
+                destination = os.path.join(out_dir, config, symbol_name)
                 safe_unlink(destination)
                 subprocess.check_call(['objcopy', '--only-keep-debug', source,
                                        destination])
 
 
-def copy_symbols():
+def copy_symbols(out_dir):
     for config in CONFIGURATIONS:
         config_dir = os.path.join(SYMBOLS_DIR, config)
         mkdir_p(config_dir)
 
         for path in SYMBOLS[TARGET_PLATFORM]:
-            shutil.copy2(os.path.join(OUT_DIR, config, path), config_dir)
+            shutil.copy2(os.path.join(out_dir, config, path), config_dir)
 
     if sys.platform != 'darwin':
         return
 
-    dsym = os.path.join(SYMBOLS_INTERMEDIATE_DIR,
+    symbols_intermediate_dir = os.path.join(out_dir, 'symbols')
+    dsym = os.path.join(symbols_intermediate_dir,
                         'libchromiumcontent.dylib.dSYM')
     destination = os.path.join(SYMBOLS_DIR, 'Release', os.path.basename(dsym))
     rm_rf(destination)
@@ -261,13 +261,13 @@ def copy_symbols():
     shutil.copytree(dsym, destination)
 
 
-def copy_sources():
+def copy_sources(out_dir):
     for include_path in INCLUDE_DIRS:
         copy_headers(include_path, relative_to=SRC_DIR, destination=DIST_SRC_DIR)
     for config in CONFIGURATIONS:
         for include_path in GENERATED_INCLUDE_DIRS:
             copy_headers(include_path,
-                         relative_to=os.path.join(OUT_DIR, config, 'gen'),
+                         relative_to=os.path.join(out_dir, config, 'gen'),
                          destination=os.path.join(MAIN_DIR, config, 'gen'))
 
     for path in OTHER_HEADERS + OTHER_SOURCES:

--- a/script/update
+++ b/script/update
@@ -103,12 +103,14 @@ def gyp_env(target_arch):
 
   # Disable NaCl. We don't need it, and it requires some very long filepaths
   # which often overrun the Windows file path limit.
-  if 'disable_nacl=1' not in env.get('GYP_DEFINES', ''):
-    env['GYP_DEFINES'] = ' '.join(['disable_nacl=1', env.get('GYP_DEFINES', '')])
+  gyp_defines = 'disable_nacl=1'
 
   env['GYP_GENERATORS'] = 'ninja'
 
   if sys.platform == 'darwin':
+    # host_arch seems to be required.
+    gyp_defines += ' ' + 'host_arch=x64'
+
     # Use Xcode's own clang instead of Chromium's. This matches what embedding
     # applications will use, reducing the risk of bugs due to version
     # mismatches.
@@ -121,8 +123,8 @@ def gyp_env(target_arch):
     env['GYP_MSVS_VERSION'] = '2013'
 
   # Build 32-bit or 64-bit.
-  env['GYP_DEFINES'] = ' '.join(['target_arch={0}'.format(target_arch),
-                                 env.get('GYP_DEFINES', '')])
+  gyp_defines += ' ' + 'target_arch={0}'.format(target_arch)
+  env['GYP_DEFINES'] = gyp_defines
 
   # Build in "out32" for 32bit target.
   if target_arch == 'ia32':

--- a/script/update
+++ b/script/update
@@ -34,10 +34,11 @@ def main():
           run_gyp(args.target_arch) or
           install_win_tool_wrapper())
 
+
 def parse_args():
-    parser = argparse.ArgumentParser(description='Update build configuration')
-    parser.add_argument('-t', '--target_arch', default='x64', help='x64 or ia32')
-    return parser.parse_args()
+  parser = argparse.ArgumentParser(description='Update build configuration')
+  parser.add_argument('-t', '--target_arch', default='x64', help='x64 or ia32')
+  return parser.parse_args()
 
 
 def chromium_version():
@@ -98,32 +99,36 @@ def tar_xf(filename):
 
 
 def gyp_env(target_arch):
-    env = os.environ.copy()
+  env = os.environ.copy()
 
-    # Disable NaCl. We don't need it, and it requires some very long filepaths
-    # which often overrun the Windows file path limit.
-    if 'disable_nacl=1' not in env.get('GYP_DEFINES', ''):
-        env['GYP_DEFINES'] = ' '.join(['disable_nacl=1', env.get('GYP_DEFINES', '')])
+  # Disable NaCl. We don't need it, and it requires some very long filepaths
+  # which often overrun the Windows file path limit.
+  if 'disable_nacl=1' not in env.get('GYP_DEFINES', ''):
+    env['GYP_DEFINES'] = ' '.join(['disable_nacl=1', env.get('GYP_DEFINES', '')])
 
-    env['GYP_GENERATORS'] = 'ninja'
+  env['GYP_GENERATORS'] = 'ninja'
 
-    if sys.platform == 'darwin':
-        # Use Xcode's own clang instead of Chromium's. This matches what embedding
-        # applications will use, reducing the risk of bugs due to version
-        # mismatches.
-        env['CC_target'] = 'clang'
-        env['CXX_target'] = 'clang++'
-    elif sys.platform in ['win32', 'cygwin']:
-        # Don't use the auto-installed VS2013 Express toolchain from depot_tools.
-        # We have our own.
-        env['DEPOT_TOOLS_WIN_TOOLCHAIN'] = '0'
-        env['GYP_MSVS_VERSION'] = '2013'
+  if sys.platform == 'darwin':
+    # Use Xcode's own clang instead of Chromium's. This matches what embedding
+    # applications will use, reducing the risk of bugs due to version
+    # mismatches.
+    env['CC_target'] = 'clang'
+    env['CXX_target'] = 'clang++'
+  elif sys.platform in ['win32', 'cygwin']:
+    # Don't use the auto-installed VS2013 Express toolchain from depot_tools.
+    # We have our own.
+    env['DEPOT_TOOLS_WIN_TOOLCHAIN'] = '0'
+    env['GYP_MSVS_VERSION'] = '2013'
 
-    # Build 32-bit or 64-bit.
-    env['GYP_DEFINES'] = ' '.join(['target_arch={0}'.format(target_arch),
-                                   env.get('GYP_DEFINES', '')])
+  # Build 32-bit or 64-bit.
+  env['GYP_DEFINES'] = ' '.join(['target_arch={0}'.format(target_arch),
+                                 env.get('GYP_DEFINES', '')])
 
-    return env
+  # Build in "out32" for 32bit target.
+  if target_arch == 'ia32':
+    env['GYP_GENERATOR_FLAGS'] = 'output_dir=out32'
+
+  return env
 
 
 def copy_chromiumcontent_files():

--- a/script/update
+++ b/script/update
@@ -110,12 +110,6 @@ def gyp_env(target_arch):
   if sys.platform == 'darwin':
     # host_arch seems to be required.
     gyp_defines += ' ' + 'host_arch=x64'
-
-    # Use Xcode's own clang instead of Chromium's. This matches what embedding
-    # applications will use, reducing the risk of bugs due to version
-    # mismatches.
-    env['CC_target'] = 'clang'
-    env['CXX_target'] = 'clang++'
   elif sys.platform in ['win32', 'cygwin']:
     # Don't use the auto-installed VS2013 Express toolchain from depot_tools.
     # We have our own.

--- a/script/update
+++ b/script/update
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import argparse
 import contextlib
 import errno
 import os
@@ -21,6 +22,8 @@ TARBALL_URL = 'https://github.com/{0}/releases/download/{1}/chromium-{1}.tar.xz'
 
 
 def main():
+  args = parse_args()
+
   version = chromium_version()
   if not is_source_tarball_updated(version):
     download_source_tarball(version)
@@ -28,8 +31,13 @@ def main():
   return (apply_patches() or
           copy_chromiumcontent_files() or
           update_clang() or
-          run_gyp() or
+          run_gyp(args.target_arch) or
           install_win_tool_wrapper())
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Update build configuration')
+    parser.add_argument('-t', '--target_arch', default='x64', help='x64 or ia32')
+    return parser.parse_args()
 
 
 def chromium_version():
@@ -89,7 +97,7 @@ def tar_xf(filename):
   os.remove(tar_name)
 
 
-def gyp_env():
+def gyp_env(target_arch):
     env = os.environ.copy()
 
     # Disable NaCl. We don't need it, and it requires some very long filepaths
@@ -100,13 +108,20 @@ def gyp_env():
     env['GYP_GENERATORS'] = 'ninja'
 
     if sys.platform == 'darwin':
-        # Build 64-bit
-        env['GYP_DEFINES'] = ' '.join(['host_arch=x64 target_arch=x64', env.get('GYP_DEFINES', '')])
+        # Use Xcode's own clang instead of Chromium's. This matches what embedding
+        # applications will use, reducing the risk of bugs due to version
+        # mismatches.
+        env['CC_target'] = 'clang'
+        env['CXX_target'] = 'clang++'
     elif sys.platform in ['win32', 'cygwin']:
         # Don't use the auto-installed VS2013 Express toolchain from depot_tools.
         # We have our own.
         env['DEPOT_TOOLS_WIN_TOOLCHAIN'] = '0'
         env['GYP_MSVS_VERSION'] = '2013'
+
+    # Build 32-bit or 64-bit.
+    env['GYP_DEFINES'] = ' '.join(['target_arch={0}'.format(target_arch),
+                                   env.get('GYP_DEFINES', '')])
 
     return env
 
@@ -141,14 +156,14 @@ def update_clang():
   return subprocess.call([sys.executable, update])
 
 
-def run_gyp():
+def run_gyp(target_arch):
   os.chdir(SRC_DIR)
   gyp = os.path.join('build', 'gyp_chromium')
   relative_dir = os.path.relpath(CHROMIUMCONTENT_DESTINATION_DIR, SRC_DIR)
   return subprocess.call(
       [sys.executable, gyp, '-Ichromiumcontent/chromiumcontent.gypi',
        os.path.join(relative_dir, 'chromiumcontent.gyp')],
-      env=gyp_env())
+      env=gyp_env(target_arch))
 
 
 def install_win_tool_wrapper():

--- a/script/upload
+++ b/script/upload
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import argparse
 import errno
 import glob
 import os
@@ -14,13 +15,6 @@ S3PUT = {
                                            'Scripts', 's3put')],
 }.get(sys.platform, ['s3put'])
 
-ARCH = {
-    'cygwin': '32bit',
-    'darwin': '64bit',
-    'linux2': platform.architecture()[0],
-    'win32': '32bit',
-}[sys.platform]
-
 PLATFORM_KEY = {
     'cygwin': 'win',
     'darwin': 'osx',
@@ -30,12 +24,20 @@ PLATFORM_KEY = {
 
 
 def main():
-    try:
-        ensure_s3put()
-        upload()
-        clean_up()
-    except AssertionError as e:
-        return e.message
+  args = parse_args()
+
+  try:
+    ensure_s3put()
+    upload(args.target_arch)
+    clean_up()
+  except AssertionError as e:
+    return e.message
+
+
+def parse_args():
+  parser = argparse.ArgumentParser(description='Upload distribution')
+  parser.add_argument('-t', '--target_arch', default='x64', help='x64 or ia32')
+  return parser.parse_args()
 
 
 def ensure_s3put():
@@ -61,23 +63,28 @@ def ensure_s3put():
         S3PUT[1] = temp.name
 
 
-def upload():
-    os.chdir(SOURCE_ROOT)
-    bucket, access_key, secret_key = s3_config()
-    commit = command_output(['git', 'rev-parse', 'HEAD']).strip()
+def upload(target_arch):
+  os.chdir(SOURCE_ROOT)
+  bucket, access_key, secret_key = s3_config()
+  commit = command_output(['git', 'rev-parse', 'HEAD']).strip()
 
-    args = S3PUT + [
-        '--bucket', bucket,
-        '--access_key', access_key,
-        '--secret_key', secret_key,
-        '--prefix', SOURCE_ROOT,
-        '--key_prefix', 'libchromiumcontent/{0}/{1}/{2}'.format(PLATFORM_KEY, ARCH,
-                                                                commit),
-        '--grant', 'public-read',
-        '--multipart'
-    ] + glob.glob('libchromiumcontent*.zip')
+  if target_arch == 'ia32':
+    arch = '32bit'
+  else:
+    arch = '64bit'
 
-    subprocess.check_call(args)
+  args = S3PUT + [
+    '--bucket', bucket,
+    '--access_key', access_key,
+    '--secret_key', secret_key,
+    '--prefix', SOURCE_ROOT,
+    '--key_prefix', 'libchromiumcontent/{0}/{1}/{2}'.format(PLATFORM_KEY, arch,
+                                                            commit),
+    '--grant', 'public-read',
+    '--multipart'
+  ] + glob.glob('libchromiumcontent*.zip')
+
+  subprocess.check_call(args)
 
 
 def s3_config():


### PR DESCRIPTION
This is required for supporting 64bit on Windows, it also makes it possible to do cross building.